### PR TITLE
fix token renewal for matrix and nextcloud

### DIFF
--- a/intercom/app.js
+++ b/intercom/app.js
@@ -46,6 +46,7 @@ const {
   refreshTokenIfNeeded,
   refreshNextcloudTokenIfNeeded,
   updateSessionState,
+  refreshMatrixTokenIfNeeded,
 } = require("./middlewares");
 
 const csrfProtection = csrfDSC({ cookie: { sameSite: "none", secure: true } });
@@ -142,6 +143,7 @@ app.use(
   refreshTokenIfNeeded,
   csrfProtection.validate,
   oidcVerifyDecodeAccessToken(attemptSilentLogin),
+  refreshMatrixTokenIfNeeded,
   nob,
 );
 

--- a/intercom/middlewares/index.js
+++ b/intercom/middlewares/index.js
@@ -4,7 +4,7 @@
  */
 
 const { oidcVerifyDecodeAccessToken, oidcVerifyDecodeIdentityToken } = require("./jwt");
-const { refreshTokenIfNeeded, refreshNextcloudTokenIfNeeded } = require("./tokenRenewal");
+const { refreshTokenIfNeeded, refreshNextcloudTokenIfNeeded, refreshMatrixTokenIfNeeded } = require("./tokenRenewal");
 const { updateSessionState } = require("./sessionState");
 
 module.exports = {
@@ -12,5 +12,6 @@ module.exports = {
   oidcVerifyDecodeIdentityToken,
   refreshTokenIfNeeded,
   refreshNextcloudTokenIfNeeded,
+  refreshMatrixTokenIfNeeded,
   updateSessionState,
 };

--- a/intercom/middlewares/tokenRenewal.js
+++ b/intercom/middlewares/tokenRenewal.js
@@ -3,10 +3,10 @@
  * SPDX-FileCopyrightText: 2024 Univention GmbH
  */
 
-const { verifyJWT, JWKS, fetchOIDCToken, logger } = require("../utils");
+const { verifyJWT, JWKS, fetchOIDCToken, fetchMatrixToken, logger } = require("../utils");
 const { issuerBaseURL } = require("../config");
 
-const refreshTokenIfNeeded = async (req, res, next) => {
+const refreshTokenIfNeeded = async (req, _, next) => {
   try {
     let { token_type, access_token, isExpired, refresh } = req.oidc.accessToken;
     if (isExpired()) {
@@ -16,21 +16,22 @@ const refreshTokenIfNeeded = async (req, res, next) => {
     }
   } catch (err) {
     logger.error("Refreshing ICS expired access_token failed");
+  } finally {
+    next();
   }
-  next();
 };
 
-const refreshNextcloudTokenIfNeeded = async (req, res, next) => {
+const refreshNextcloudTokenIfNeeded = async (req, _, next) => {
   try {
-    const nc_access_token = await verifyJWT(
+    _ = await verifyJWT(
       req.appSession.nc_access_token,
       issuerBaseURL,
       JWKS
     );
     logger.debug("Nextcloud access_token is valid");
   } catch (error) {
-    if (error.code == "ERR_JWT_EXPIRED") {
-      logger.warn("Nextcloud access_token expired, refreshing");
+    if (error.code == "ERR_JWT_EXPIRED" || error.code == "ERR_JWS_INVALID") {
+      logger.warn("Nextcloud access_token expired or invalid, refreshing");
       logger.warn("Catched info:", error);
       req.appSession.nc_access_token = await fetchOIDCToken(
         req.appSession.access_token,
@@ -43,7 +44,29 @@ const refreshNextcloudTokenIfNeeded = async (req, res, next) => {
   }
 };
 
+const refreshMatrixTokenIfNeeded = async (req, _, next) => {
+  try {
+    _ = await verifyJWT(
+      req.appSession.matrix_access_token,
+      issuerBaseURL,
+      JWKS
+    );
+    logger.debug("Matrix access_token is valid");
+  } catch (error) {
+    if (error.code == "ERR_JWT_EXPIRED" || error.code == "ERR_JWS_INVALID") {
+      logger.warn("Matrix access_token expired or invalid, refreshing");
+      logger.warn("Catched info:", error);
+      let entryUUID = req.decodedAccessToken[process.env.USER_UNIQUE_MAPPER ?? "entryuuid"];
+      req.appSession.matrix_access_token = await fetchMatrixToken(entryUUID);
+      logger.info("Refreshed successfully");
+    }
+  } finally {
+    next();
+  }
+};
+
 module.exports = {
   refreshTokenIfNeeded,
   refreshNextcloudTokenIfNeeded,
+  refreshMatrixTokenIfNeeded
 };


### PR DESCRIPTION
This PR fixes some issues with token refreshing of nextcloud and matrix.

In particular, if a user logs into Webmail (OX) before a Matrix or Nextcloud Account for the User exists, the intercom is left in a faulty state. The tokens for the applications in the session are invalid and never renewed. The only way for the user to fix this is to nuke the session in the browser or use a different browser session.

With the changes attached the tokens are refreshed when the token in the session is invalid, which means the integrations start working the moment the user is created in the respective application.

This repository seems to be only a mirror and it's not clear how contributions can be made so I started with the PR. If the changes should be submitted another way, please let us know.