### PR TITLE
feat: Add optional Redis TLS servername (SNI) support

### DIFF
--- a/helm/intercom-service/templates/secret.yaml
+++ b/helm/intercom-service/templates/secret.yaml
@@ -55,6 +55,9 @@ stringData:
   REDIS_PORT: {{ .redis.port | quote }}
   REDIS_SSL: {{ .redis.ssl.enabled | quote }}
   REDIS_MTLS: {{ .redis.ssl.mTLS.enabled | quote }}
+  {{- if .redis.ssl.servername }}
+  REDIS_SERVERNAME: {{ .redis.ssl.servername | quote }}
+  {{- end }}
   {{- if .redis.username }}
   REDIS_USER: {{ .redis.username | quote }}
   {{- end }}

--- a/helm/intercom-service/values.yaml
+++ b/helm/intercom-service/values.yaml
@@ -345,6 +345,9 @@ ics:
       # -- Optional. Path to the Redis custom CA
       pathCA: "/etc/ssl/certs/redis-custom-CA.pem"
 
+      # -- Optional. Server name for the SNI (Server Name Indication)
+      servername: ""
+
       # -- CustomCA certificate for Redis connection
       customca: ""
 

--- a/intercom/config/config.js
+++ b/intercom/config/config.js
@@ -77,6 +77,7 @@ const config = {
     caPath: process.env.NODE_EXTRA_CA_CERTS ?? "...",
     mTLS: JSON.parse((process.env.REDIS_MTLS ?? "false").toLowerCase()),
     SSL: JSON.parse((process.env.REDIS_SSL ?? "false").toLowerCase()),
+    servername: process.env.REDIS_SERVERNAME || undefined,
   },
 };
 

--- a/intercom/utils/redis.js
+++ b/intercom/utils/redis.js
@@ -38,6 +38,7 @@ if ( redis.SSL ){
       url: `rediss://${redis.user}:${redis.password}@${redis.host}:${redis.port}`,
       socket: {
         tls: true,
+        ...(redis.servername ? { servername: redis.servername } : {}),
         ...tlsOptions,
       },
     });


### PR DESCRIPTION
## Summary

This change adds optional support for configuring the TLS **servername (SNI)** when establishing a Redis connection. The value is passed to the Redis client via `socket.servername`.

The servername can be configured through the environment variable:

```
REDIS_SERVERNAME
```

If the variable is not set, the Redis client behavior remains unchanged.

---

## Motivation

Some Redis deployments require **Server Name Indication (SNI)** during the TLS handshake. This commonly occurs when Redis is accessed through:

* TLS proxies or load balancers
* managed cloud services (e.g. AWS ElastiCache, Azure Cache for Redis)
* environments where the Redis endpoint is accessed via an IP address but the TLS certificate is issued for a hostname
* Kubernetes ingress or service mesh TLS termination

In these setups, the TLS endpoint may host multiple certificates or routes and requires the client to send the correct server name in the TLS ClientHello.

Without SNI, connections may fail with certificate validation errors such as:

```
ERR_TLS_CERT_ALTNAME_INVALID
```

---

## Implementation

The Redis client configuration now conditionally forwards the configured servername to the Node Redis client:

```js
socket: {
  tls: true,
  ...(redis.servername ? { servername: redis.servername } : {}),
  ...tlsOptions,
}
```

The option is only added if `REDIS_SERVERNAME` is defined, ensuring backward compatibility and avoiding passing `undefined` values to the TLS configuration.

---

## Backwards Compatibility

This change is fully backward compatible:

* Existing configurations continue to work unchanged
* SNI is only enabled when `REDIS_SERVERNAME` is explicitly configured
* Default Redis deployments without TLS routing requirements are unaffected

---

## Example configuration

With SNI:

```
REDIS_SSL=true
REDIS_SERVERNAME=redis.example.com
```

Without SNI (default behavior):

```
REDIS_SSL=true
```

---

## Why `REDIS_SERVERNAME`

The environment variable name mirrors the Node.js TLS option `servername`, which keeps the configuration explicit and avoids coupling the environment variable naming to a specific Redis client implementation.