### PR TITLE
fix(chart): Fix wrong values reference to .ics.redis.auth.username

### DIFF
--- a/helm/intercom-service/templates/secret.yaml
+++ b/helm/intercom-service/templates/secret.yaml
@@ -55,8 +55,8 @@ stringData:
   REDIS_PORT: {{ .redis.port | quote }}
   REDIS_SSL: {{ .redis.ssl.enabled | quote }}
   REDIS_MTLS: {{ .redis.ssl.mTLS.enabled | quote }}
-  {{- if .redis.username }}
-  REDIS_USER: {{ .redis.username | quote }}
+  {{- if .redis.auth.username }}
+  REDIS_USER: {{ .redis.auth.username | quote }}
   {{- end }}
   # OIDC
   CLIENT_ID: {{ .oidc.id }}


### PR DESCRIPTION
https://forge.univention.org/bugzilla/show_bug.cgi?id=59490

In the values.yaml file, the credentials for Redis are under the values `ics.redis.auth.{username,password}`. However, there is currently a bug and the username is taken from the value `ics.redis.username`.