### PR TITLE
feat: add top-level extraEnvVars for main intercom-service container

### DIFF
--- a/helm/intercom-service/templates/deployment.yaml
+++ b/helm/intercom-service/templates/deployment.yaml
@@ -185,7 +185,7 @@ spec:
             - name: NODE_EXTRA_CA_CERTS
               value: "{{ .Values.ics.redis.ssl.pathCA }}"
             {{- end }}
-            {{- with .Values.provisioning.extraEnvVars }}
+            {{- with .Values.extraEnvVars }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
           envFrom:

--- a/helm/intercom-service/values.yaml
+++ b/helm/intercom-service/values.yaml
@@ -578,6 +578,20 @@ updateStrategy:
   # are destroyed first.
   type: "RollingUpdate"
 
+# -- Array with extra environment variables to add to the main intercom-service container.
+# This is different from provisioning.extraEnvVars which only affects init containers.
+# Provide name and either value, valueFrom, or both.
+#
+# extraEnvVars:
+#   - name: FOO
+#     value: "bar"
+#   - name: BAZ
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: secret-key
+extraEnvVars: []
+
 # -- The Intercom Service Keycloak provisioning job
 provisioning:
 


### PR DESCRIPTION
## feat: Add top-level extraEnvVars for main intercom-service container

### Summary

Adds a new top-level `extraEnvVars` parameter that extends the main `intercom-service` container's environment variables. Previously, only `provisioning.extraEnvVars` existed, which applies to init containers (wait-for-keycloak, keycloak-provisioning). This forced downstream forks to duplicate chart templates or modify upstream secrets when adding new features like custom proxy routes.

**This is backwards compatible** — default is an empty array, so existing deployments are unaffected.

### Motivation

**Problem:** The Univention intercom-service chart currently has no mechanism to inject additional environment variables into the **main** `intercom-service` container. Workarounds include:
1. Patching `templates/deployment.yaml` directly
2. Modifying upstream secrets to include extra fields
3. Duplicating chart templates in downstream forks

All these approaches create maintenance burdens when upstream changes occur.

**Solution:** Following the existing `provisioning.extraEnvVars` pattern established for init containers, add a top-level `extraEnvVars` value specifically for the main service container.

### Changes

#### `values.yaml`
- Add new parameter `extraEnvVars` with documentation and example usage
- Clarifies semantic difference from `provisioning.extraEnvVars`

#### `templates/deployment.yaml`
- Fix incorrect usage of `.Values.provisioning.extraEnvVars` in main container
- Now correctly uses `.Values.extraEnvVars` for main service container

### Example Usage

```yaml
# values.yaml
extraEnvVars:
  - name: CUSTOM_DEBUG_FLAG
    value: "true"
  - name: SERVICE_ID
    value: "my-service"
  - name: EXTERNAL_SECRET
    valueFrom:
      secretKeyRef:
        name: external-secret
        key: api-key
```

### Use Cases

1. **Downstream Fork Extensions** — openDesk Edu fork uses this to enable new proxy routes (`OC_ENABLED`, `SOGO_ENABLED`, `ILIAS_ENABLED`, `OC_URL`, etc.) without chart template modifications.

2. **Site-Specific Features** — Custom telemetry, feature flags, or integration hooks.

3. **Debug & Development** — Temporary env var overrides without secret modifications.

### Testing

- Validated with `helm template` — extraEnvVars correctly renders in main container's env list
- Init containers continue to use `provisioning.extraEnvVars` (unchanged behavior)
- Backwards compatible — empty default array means no env var changes on existing deployments

### Breaking Changes

None. The change is fully additive and backwards compatible.

### Related Issues

- Enables modular extensions without forking chart templates
- Consistent with Kubernetes best practices (init vs main container separation)